### PR TITLE
fix workshop collection loading and add new official maps

### DIFF
--- a/OfficialMaps.json
+++ b/OfficialMaps.json
@@ -2,8 +2,14 @@
     "name": "ar_baggage",
     "id": 125440026
 },{
+    "name": "ar_poolday",
+    "id": 3263935964
+},{
     "name": "ar_shoots",
     "id" : 125440261
+},{
+    "name": "cs_assault",
+    "id": 125432575
 },{
     "name": "cs_italy",
     "id": 125436057
@@ -17,11 +23,20 @@
     "name": "de_anubis",
     "id": 1984883124
 },{
+    "name": "de_assembly",
+    "id": 3071005299
+},{
     "name": "de_dust2",
     "id": 125438255
 },{
     "name": "de_inferno",
     "id": 125438669
+},{
+    "name": "de_memento",
+    "id": 3165559377
+},{
+    "name": "de_mills",
+    "id": 3152430710
 },{
     "name": "de_mirage",
     "id": 152508932
@@ -31,6 +46,9 @@
 },{
     "name": "de_overpass",
     "id": 205240106
+},{
+    "name": "de_thera",
+    "id": 3121217565
 },{
     "name": "de_vertigo",
     "id": 125439851

--- a/modules/sharedFunctions.js
+++ b/modules/sharedFunctions.js
@@ -122,20 +122,24 @@ async function reloadMaplist() {
                             try {
                                 let resJson = JSON.parse(resData);
                                 resJson.response.publishedfiledetails.forEach( details => {
-                                    let _mapName = "";
-                                    if (details.filename != "") {
-                                        let re = /\S+\/(\S+).bsp/;
-                                        let matches = details.filename.match(re);
-                                        _mapName = matches[1];
+                                    if (details.result == 1) {
+                                        let _mapName = "";
+                                        if (details.filename != "") {
+                                            let re = /\S+\/(\S+).bsp/;
+                                            let matches = details.filename.match(re);
+                                            _mapName = matches[1];
+                                        }
+                                        returnDetails.push({ 
+                                            "name": _mapName, 
+                                            "official": official, 
+                                            "title": details.title, 
+                                            "workshopID": details.publishedfileid.toString(), 
+                                            "description": details.description, 
+                                            "previewLink": details.preview_url, 
+                                            "tags": details.tags });
+                                    } else {
+                                        logger.warn(`No details for map ${details.publishedfileid.toString()}. Query Result: ${details.result.toString()}`);
                                     }
-                                    returnDetails.push({ 
-                                        "name": _mapName, 
-                                        "official": official, 
-                                        "title": details.title, 
-                                        "workshopID": details.publishedfileid.toString(), 
-                                        "description": details.description, 
-                                        "previewLink": details.preview_url, 
-                                        "tags": details.tags })
                                 });
                                 resolve(returnDetails);
                             } catch (e) {


### PR DESCRIPTION
If a collection has maps, that for some reason do not return details, but don't make the whole query fail, now only a warning is logged, but the other maps still load.